### PR TITLE
allow manually setting `categories`.

### DIFF
--- a/controllers/ApiBrowserController.php
+++ b/controllers/ApiBrowserController.php
@@ -51,7 +51,19 @@ class ApiBrowserController extends \lithium\action\Controller {
 	 */
 	public function index() {
 		$indexer = $this->_classes['indexer'];
-		return array('libraries' => $indexer::libraries());
+		$libraries = $indexer::libraries();
+
+		$config = Libraries::get('li3_docs');
+		$categories = '';
+		if (isset($config['categories']) && is_array($config['categories'])) {
+			$categories = array_keys($config['categories']);
+		} else {
+			$categories = array_values(array_unique(
+					array_map(function($lib) { return $lib['category']; }, $libraries)
+			));
+		}
+
+		return compact('libraries', 'categories');
 	}
 
 	/**

--- a/extensions/docs/Extractor.php
+++ b/extensions/docs/Extractor.php
@@ -68,7 +68,20 @@ class Extractor extends \lithium\core\StaticObject {
 				unset($config[$language]);
 			}
 		}
-		return $config + array('title' => Inflector::humanize($name), 'category' => 'libraries');
+		$docConfig = Libraries::get('li3_docs');
+		$category = 'libraries';
+		if (isset($docConfig['categories']) && is_array($docConfig['categories'])) {
+			if (isset($config['category'])) {
+				unset($config['category']);
+			}
+			foreach ($docConfig['categories'] as $key => $include) {
+				if ($include === true || !in_array($name, array_values((array)$include))) {
+					continue;
+				}
+				$category = $key;
+			}
+		}
+		return $config + array('title' => Inflector::humanize($name), 'category' => $category);
 	}
 
 	protected static function _method(array $object, array $data, array $options = array()) {

--- a/views/api_browser/index.html.php
+++ b/views/api_browser/index.html.php
@@ -2,47 +2,45 @@
 
 use lithium\util\Inflector;
 
-$categories = array_values(array_unique(
-	array_map(function($lib) { return $lib['category']; }, $libraries)
-));
 $defaults = array('controller' => 'li3_docs.ApiBrowser', 'action' => 'view');
 
 ?>
 
 <div class="nav">
-	<h2><?=$this->title($t('Libraries', array('scope' => 'li3_docs'))); ?></h2>
-	<nav>
-		<ul class="libraries">
-			<?php foreach ($libraries as $lib => $config) { ?>
-				<li>
-					<div class="title">
-						<?=$this->html->link($lib, compact('lib') + $defaults); ?>
-					</div>
-				</li>
-			<?php } ?>
-		</ul>
-	</nav>
+	<?php foreach ($categories as $cat): ?>
+		<h2><?=$this->title($t(Inflector::humanize($cat), array('scope' => 'li3_docs'))); ?></h2>
+		<nav>
+			<ul class="libraries">
+				<?php foreach ($libraries as $lib => $config) { ?>
+					<?php if ($config['category'] != $cat) { continue; } ?>
+					<li>
+						<div class="title">
+							<?=$this->html->link($lib, compact('lib') + $defaults); ?>
+						</div>
+					</li>
+				<?php } ?>
+			</ul>
+		</nav>
+	<?php endforeach ?>
 </div>
 
 <?php foreach ($categories as $cat): ?>
+	<div class="section">
+		<section>
+			<h3><?=$this->title($t(Inflector::humanize($cat), array('scope' => 'li3_docs'))); ?></h3>
 
-<div class="section">
-	<section>
-		<h3><?=$this->title($t(Inflector::humanize($cat), array('scope' => 'li3_docs'))); ?></h3>
-		<?php foreach ($libraries as $lib => $config) { ?>
-			<?php if ($config['category'] != $cat): ?>
-				<?php continue; ?>
-			<?php endif ?>
-			<h4 class="title">
-				<?=$this->html->link($config['title'], compact('lib') + $defaults); ?>
-			</h4>
-			<?php if (isset($config['description'])) { ?>
-				<div class="library-description markdown">
-					<pre><?=$config['description']; ?></pre>
-				</div>
+			<?php foreach ($libraries as $lib => $config) { ?>
+				<?php if ($config['category'] != $cat) { continue; } ?>
+				<h4 class="title">
+					<?=$this->html->link($config['title'], compact('lib') + $defaults); ?>
+				</h4>
+				<?php if (isset($config['description'])) { ?>
+					<div class="library-description markdown">
+						<pre><?=$config['description']; ?></pre>
+					</div>
+				<?php } ?>
 			<?php } ?>
-		<?php } ?>
-	</section>
-</div>
 
+		</section>
+	</div>
 <?php endforeach ?>


### PR DESCRIPTION
This will override any info found, and also specify the sequence the categories are listed.
`libraries` is the default category, and must be included in the configuration. Set its value
to true, all non-listed modules in the other categories will be assigned to `libraries`.

Eg:
'categories' => array(
    'application' => 'app',
    'libraries' => true,
    'whatever' => array('lib1', 'lib2')
)
