### PR TITLE
Make Left Nav Show Two Levels

### DIFF
--- a/extensions/docs/Extractor.php
+++ b/extensions/docs/Extractor.php
@@ -20,11 +20,11 @@ class Extractor extends \lithium\core\StaticObject {
 	public static function get($library, $identifier, array $options = array()) {
 		$defaults = array('namespaceDoc' => array(), 'language' => 'en');
 		$options += $defaults;
-		$options['namespaceDoc'] = (array)$options['namespaceDoc'];
+		$options['namespaceDoc'] = (array) $options['namespaceDoc'];
 		$config = Libraries::get('li3_docs');
 		if (isset($config['namespaceDoc'])) {
 			$options['namespaceDoc'] = array_merge(
-					$options['namespaceDoc'], (array)$config['namespaceDoc']
+					$options['namespaceDoc'], (array) $config['namespaceDoc']
 			);
 		}
 
@@ -83,7 +83,7 @@ class Extractor extends \lithium\core\StaticObject {
 				unset($config['category']);
 			}
 			foreach ($docConfig['categories'] as $key => $include) {
-				if ($include === true || !in_array($name, array_values((array)$include))) {
+				if ($include === true || !in_array($name, array_values((array) $include))) {
 					continue;
 				}
 				$category = $key;
@@ -127,7 +127,7 @@ class Extractor extends \lithium\core\StaticObject {
 		}
 
 		$object['text'] = null;
-		foreach((array)$options['namespaceDoc'] as $namespaceDoc) {
+		foreach ((array) $options['namespaceDoc'] as $namespaceDoc) {
 			$doc = "{$path}/{$namespaceDoc}";
 			if (!file_exists($doc)) {
 				continue;
@@ -160,9 +160,15 @@ class Extractor extends \lithium\core\StaticObject {
 		}
 
 		foreach ($contents as $key => $value) {
-			$result[isset($value['title']) ? $value['title'] : $key] = array(
-				'type' => "page", 'url' => "{$library}/{$key}"
+			$section = isset($value['title']) ? $value['title'] : $key;
+			$url = "{$library}/{$key}";
+			$result[$section] = array(
+				'type' => "page", 'url' => $url
 			);
+			if (isset($value['contents'])) {
+				$object['library'] = $url;
+				$result[$section]['contents'] = static::_contents($object, $value['contents']);
+			}
 		}
 		return $result;
 	}

--- a/extensions/helper/Docs.php
+++ b/extensions/helper/Docs.php
@@ -8,7 +8,7 @@
 
 namespace li3_docs\extensions\helper;
 
-class Docs extends \lithium\template\Helper {
+class Docs extends \lithium\template\helper\Html {
 
 	public function cleanup($text) {
 		return preg_replace('/\n\s+-\s/msi', "\n\n - ", $text);
@@ -58,6 +58,32 @@ class Docs extends \lithium\template\Helper {
 		}
 		$crumbs[] = array('title' => $ident, 'url' => null, 'class' => $isMethod ? 'ident' : null);
 		return $crumbs;
+	}
+
+	public function contents($children) {
+		$list = '';
+		foreach ($children as $name => $type) {
+			if (is_array($type)) {
+				extract($type, EXTR_OVERWRITE);
+			}
+			if (!isset($url)) {
+				$url = $this->identifierUrl($name);
+				$parts = explode('\\', $name);
+				$name = basename(end($parts));
+			} else {
+				$url = $this->pageUrl($url);
+			}
+			if (!isset($contents)) {
+				$list .= "<li class='$type'>" . $this->link($name, $url) . '</li>';
+			} else {
+				$list .= "<li class='$type'>" . $this->link($name, $url);
+				$list .= '<ul class="children">' . $this->contents($contents) . '</ul>';
+				$list .= '</li>';
+			}
+
+			unset($url);
+		}
+		return $list;
 	}
 }
 

--- a/views/elements/contents.html.php
+++ b/views/elements/contents.html.php
@@ -3,22 +3,7 @@
 	<?php if ($object['children']) { ?>
 		<h2><?=$t('Contents', array('scope' => 'li3_docs')); ?></h2>
 		<ul class="children">
-			<?php foreach ($object['children'] as $name => $type) { ?>
-				<?php
-					if (is_array($type)) {
-						extract($type, EXTR_OVERWRITE);
-					}
-					if (!isset($url)) {
-						$url = $this->docs->identifierUrl($name);
-						$parts = explode('\\', $name);
-						$name = basename(end($parts));
-					} else {
-						$url = $this->docs->pageUrl($url);
-					}
-				?>
-				<li class="<?=$type; ?>"><?=$this->html->link($name, $url); ?></li>
-				<?php unset($url); ?>
-			<?php } ?>
+			<?= $this->docs->contents($object['children']); ?>
 		</ul>
 	<?php } ?>
 	</nav>

--- a/webroot/css/li3_docs.css
+++ b/webroot/css/li3_docs.css
@@ -324,6 +324,14 @@ ul.parameters {
 .children > li.file {
 	background-image: url("/li3_docs/img/icons/silk/page_white.png");
 }
+.children > li > .children {
+	margin-left: 0;
+}
+.children > li > .children > li {
+	background-image: url("/li3_docs/img/icons/silk/page_white.png");
+	border-left: none;
+	font-size: 90%;
+}
 .properties > li {
 	background: url("/li3_docs/img/icons/silk/cog.png") no-repeat 0 6px;
 	padding: .25em 0 .25em 26px;


### PR DESCRIPTION
This change adjusts the left navigation to accomodate the manual better. API docs are well suited to a shallow view, but the manual needs at least two levels of navigation to be very effective.
