### PR TITLE
Enable use of blockquote in markdown documentation

### DIFF
--- a/webroot/css/li3_docs.css
+++ b/webroot/css/li3_docs.css
@@ -229,6 +229,11 @@ body.docs .crumbs h3 {
 	text-align: justify;
 }
 
+.markdown blockquote {
+    font-size: 1em;
+    background-color: #efefef;
+}
+
 .text.markdown li {
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
Updates the CSS for blockquote as a way to call out tips, tricks, hints, etc in the user guide.
