### PR TITLE
Fleshed out url config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,27 @@ Once loaded into your application the plugin will enable browsing for all added 
 		'index' => array('lithium', 'li3_bot')
 	));
 
+By default, the url to view the docs is `'/docs'`. This can be customized with the `'url'` option in the second paramter when adding Li3 Docs:
+
+	Libraries::add('li3_docs', array(
+		'url' => '/documentation'
+	));
+
+Or if you wanted to have an app who's sole purpose is displaying docs, you could add all of your libraries and plugins to that app with `'bootstrap' => false` in the second parameter when adding the libraries with `Libraries::add()`. Then point the Li3 Docs url to the root of the app:
+
+	Libraries::add('li3_docs', array(
+		'url' => '/'
+	));
+
+
 ### Searching
 
 The plugin now features a symbol-based live search. Search for classes, methods and properties using the search bar near the top of the page. By default, any term entered into the box will trigger a search across all symbol types. You can refine your search by entering in specially formed queries:
 
-* If the first letter in the query is upper-case, you will only get _classes_ in the results. 
+* If the first letter in the query is upper-case, you will only get _classes_ in the results.
 * If the query contains a $, only _properties_ will be shown in the results.
 * If the query ends with or contains a parenthesis, you'll only be searching _methods_.
 
 To update the search database, run the symbol harvesting task:
 
 	$ li3 harvest
-

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -40,6 +40,16 @@ Dispatcher::applyFilter('run', $filter);
 ConsoleDispatcher::applyFilter('run', $filter);
 
 /**
+ * Setup default options
+ */
+$config = Libraries::get('li3_docs');
+$config += array(
+	'url' => '/docs'
+);
+$config['bootstrap'] = false;
+Libraries::add('li3_docs', $config);
+
+/**
  * Set up Sqlite3 database for search functionality.
  */
 require __DIR__ . '/bootstrap/connections.php';

--- a/config/routes.php
+++ b/config/routes.php
@@ -8,6 +8,10 @@ use li3_docs\extensions\route\Locale;
 
 $config = Libraries::get('li3_docs');
 $base = isset($config['url']) ? $config['url'] : '/docs';
+$root = $base;
+if ($base === '/') {
+	$base = '';
+}
 
 /**
  * Handles broken URL parsers by matching method URLs with no closing ) and redirecting.
@@ -16,11 +20,7 @@ Router::connect("{$base}/{:args}\(", array(), function($request) {
 	return new Response(array('location' => "{$request->url})"));
 });
 
-Router::connect($base, array('controller' => 'li3_docs.ApiBrowser', 'action' => 'index'));
-
-Router::connect("{$base}/{:lib}/{:args}", array(
-	'controller' => 'li3_docs.ApiBrowser', 'action' => 'view'
-));
+Router::connect($root, array('controller' => 'li3_docs.ApiBrowser', 'action' => 'index'));
 
 Router::connect('/li3_docs/{:path:js|css}/{:file}.{:type}', array(), function($request) {
 	$req = $request->params;
@@ -59,6 +59,10 @@ Router::connect('/li3_docs/{:path:img}/{:args}.{:type}', array(), function($requ
 Router::connect('/li3_docs/search/{:query}', array(
 	'controller' => 'li3_docs.ApiSearch',
 	'action' => 'query'
+));
+
+Router::connect("{$base}/{:lib}/{:args}", array(
+	'controller' => 'li3_docs.ApiBrowser', 'action' => 'view'
 ));
 
 Router::connect(new Locale(array(

--- a/extensions/helper/Docs.php
+++ b/extensions/helper/Docs.php
@@ -8,7 +8,31 @@
 
 namespace li3_docs\extensions\helper;
 
+use lithium\core\Libraries;
+
 class Docs extends \lithium\template\helper\Html {
+
+	/**
+	 * The li3_docs library configuration.
+	 *
+	 * @see lithium\core\Libraries::add()
+	 * @var array
+	 */
+	protected $_libraryConfig;
+
+	/**
+	 * The configured base url for li3_docs.
+	 * Used to determing breadcrumb urls
+	 *
+	 * @var string
+	 */
+	protected $_baseUrl;
+
+	protected function _init() {
+		parent::_init();
+		$this->_libraryConfig = Libraries::get('li3_docs');
+		$this->_baseUrl = $this->_libraryConfig['url'];
+	}
 
 	public function cleanup($text) {
 		return preg_replace('/\n\s+-\s/msi', "\n\n - ", $text);
@@ -38,20 +62,20 @@ class Docs extends \lithium\template\helper\Html {
 		));
 		$crumbs[] = array(
 			'title' => $object['type'],
-			'url' => null,
+			'url' => $this->_baseUrl,
 			'class' => 'type ' . $object['type']
 		);
 		$url = '';
 
 		foreach (array_slice($path, 0, -1) as $part) {
 			$url .= '/' . $part;
-			$crumbs[] = array('title' => $part, 'url' => 'docs' . $url, 'class' => 'namespace');
+			$crumbs[] = array('title' => $part, 'url' => "{$this->_baseUrl}{$url}", 'class' => 'namespace');
 		}
 		$ident = end($path);
 
 		if (strpos($ident, '::') !== false) {
 			list($class, $ident) = explode('::', $ident, 2);
-			$crumbs[] = array('title' => $class, 'url' => "docs{$url}/{$class}", 'class' => null);
+			$crumbs[] = array('title' => $class, 'url' => "{$this->_baseUrl}{$url}/{$class}", 'class' => null);
 			$isMethod = true;
 		} else {
 			$isMethod = false;

--- a/views/layouts/default.html.php
+++ b/views/layouts/default.html.php
@@ -8,6 +8,19 @@
 
 use lithium\g11n\Locale;
 use lithium\core\Environment;
+use lithium\core\Libraries;
+
+$config = Libraries::get('li3_docs');
+$searchBase = $config['url'];
+if (strpos($searchBase, '/') === 0) {
+	$searchBase = substr($searchBase, 1);
+}
+if ($searchBase === false) {
+	$searchBase = "";
+}
+if ($searchBase !== "") {
+	$searchBase .= "/";
+}
 
 ?>
 <!doctype html>
@@ -25,8 +38,8 @@ use lithium\core\Environment;
 	<?=$this->html->script(array(
 		'/li3_docs/js/jquery-1.7.1.min.js',
 		'/li3_docs/js/jquery-ui-custom.min.js',
-		'/li3_docs/js/showdown.min.js', 
-		'/li3_docs/js/highlight.pack.js', 
+		'/li3_docs/js/showdown.min.js',
+		'/li3_docs/js/highlight.pack.js',
 		'/li3_docs/js/search.js',
 		'/li3_docs/js/rad.cli.js'
 	)); ?>
@@ -51,7 +64,7 @@ use lithium\core\Environment;
 				array('controller' => 'li3_docs.ApiBrowser', 'action' => 'index'),
 				array('escape' => false, 'title' => 'Return to Lithium Docs home')
 			); ?>
-			<div id="search" data-webroot="<?= $this->url('/'); ?>" ><?= $this->form->text('query') ?></div>
+			<div id="search" data-webroot="<?= $this->url('/'); ?>" data-base="<?= $searchBase; ?>" ><?= $this->form->text('query') ?></div>
 		</header>
 	</div>
 

--- a/webroot/css/li3_docs.css
+++ b/webroot/css/li3_docs.css
@@ -266,20 +266,20 @@ body.docs .crumbs h3 {
 	width: 1em;
 	height: 0;
 	padding: 1.25em 0 0 0;
-	background: url("/li3_docs/img/icons/silk/package.png") no-repeat center center;
+	background: url("../img/icons/silk/package.png") no-repeat center center;
 	overflow: hidden;
 }
 .crumbs .type.class {
-	background-image: url("/li3_docs/img/icons/silk/brick.png");
+	background-image: url("../img/icons/silk/brick.png");
 }
 .crumbs .type.method {
-	background-image: url("/li3_docs/img/icons/silk/wrench.png");
+	background-image: url("../img/icons/silk/wrench.png");
 }
 .crumbs .type.property {
-	background-image: url("/li3_docs/img/icons/silk/cog.png");
+	background-image: url("../img/icons/silk/cog.png");
 }
 .crumbs .type.file {
-	background-image: url("/li3_docs/img/icons/silk/page_white.png");
+	background-image: url("../img/icons/silk/page_white.png");
 }
 .crumbs .type span::after {
 	content: ':';
@@ -316,41 +316,41 @@ ul.parameters {
 	margin: 0 0 0 1em;
 }
 .libraries > li {
-	background: url("/li3_docs/img/icons/silk/package_green.png") no-repeat center left;
+	background: url("../img/icons/silk/package_green.png") no-repeat center left;
 	padding: .1em 0 .1em 26px;
 }
 .children > li, .subclasses > li {
-	background: url("/li3_docs/img/icons/silk/package.png") no-repeat 0 6px;
+	background: url("../img/icons/silk/package.png") no-repeat 0 6px;
 	padding: .1em 0 .1em 26px;
 }
 .children > li.class {
-	background-image: url("/li3_docs/img/icons/silk/brick.png");
+	background-image: url("../img/icons/silk/brick.png");
 }
 .children > li.file {
-	background-image: url("/li3_docs/img/icons/silk/page_white.png");
+	background-image: url("../img/icons/silk/page_white.png");
 }
 .children > li > .children {
 	margin-left: 0;
 }
 .children > li > .children > li {
-	background-image: url("/li3_docs/img/icons/silk/page_white.png");
+	background-image: url("../img/icons/silk/page_white.png");
 	border-left: none;
 	font-size: 90%;
 }
 .properties > li {
-	background: url("/li3_docs/img/icons/silk/cog.png") no-repeat 0 6px;
+	background: url("../img/icons/silk/cog.png") no-repeat 0 6px;
 	padding: .25em 0 .25em 26px;
 	font-family: Monaco, Courier, monospace !important;
 	font-size: .85em;
 }
 .methods > li {
-	background: url("/li3_docs/img/icons/silk/wrench.png") no-repeat 0 6px;
+	background: url("../img/icons/silk/wrench.png") no-repeat 0 6px;
 	padding: .25em 0 .25em 26px;
 	font-family: Monaco, Courier, monospace !important;
 	font-size: .85em;
 }
 .parameters > li {
-	background: url("/li3_docs/img/icons/silk/cog_go.png") no-repeat 0 6px;
+	background: url("../img/icons/silk/cog_go.png") no-repeat 0 6px;
 	padding: .25em 0 .25em 26px;
 }
 .parameters ul {
@@ -362,19 +362,19 @@ ul.parameters {
 .related > li {
 	font-size: 0.85em;
 	font-family: Monaco, Courier, monospace;
-	background: url("/li3_docs/img/icons/silk/brick_add.png") no-repeat 0 6px;
+	background: url("../img/icons/silk/brick_add.png") no-repeat 0 6px;
 	padding: .25em 0 .25em 26px;
 }
 .nav.namespace {
-	background: url("/li3_docs/img/icons/silk/package_green.png") no-repeat center left;
+	background: url("../img/icons/silk/package_green.png") no-repeat center left;
 	padding: .25em 0 .25em 26px;
 }
 .nav.class {
-	background: url("/li3_docs/img/icons/silk/package.png") no-repeat center left;
+	background: url("../img/icons/silk/package.png") no-repeat center left;
 	padding: .25em 0 .25em 26px;
 }
 .nav.method {
-	background: url("/li3_docs/img/icons/silk/wrench.png") no-repeat center left;
+	background: url("../img/icons/silk/wrench.png") no-repeat center left;
 	padding: .25em 0 .25em 26px;
 }
 h2.parent, a.parent {

--- a/webroot/js/search.js
+++ b/webroot/js/search.js
@@ -1,57 +1,67 @@
-// Listeners
-$(document).ready(function(event){
-	$('#search input').autocomplete({
-		source:getResults,
-		select:selectResult
+(function() {
+
+	var webroot, base, $el;
+
+	// Listeners
+	$(document).ready(function(event){
+		$el = $('#search');
+		webroot = $el.data('webroot');
+		base = $el.data('base');
+		$el.find('input').autocomplete({
+			source:getResults,
+			select:selectResult
+		});
+		$el.on('click', 'ui.autocomplete li a', function(event){
+			event.preventDefault();
+			selectResult(event, null);
+		});
 	});
-	$('ui.autocomplete li a').live('click', function(event){
-		event.preventDefault();
-		selectResult(event, null);
-	});
-});
 
-// Handler on select
-function selectResult(event, ui) {
-	var destination = ui.item.value;
-	var path = destination.replace(/\\/g, "/");
-	window.location.href = $('#search').data('webroot') + 'docs/' + path;
-}
-
-// jQuery UI Autocomplete source
-function getResults(term, callback) {
-	var options = [];
-	$.get(
-		$('#search').data('webroot') + 'li3_docs/search/' + term.term,
-		function(data, status, xhr) {
-			if(typeof(data.results.error) != 'undefined') {
-				alert(data.results.error);
-				return;
-			}
-			for(i in data.results) {
-				options.push(createValue(
-					data.results[i]['class'],
-					data.results[i].type,
-					data.results[i].name
-				));
-			}
-			callback(options);
-		},
-		'json'
-	);
-}
-
-// Transforms symbol results into displayable options
-function createValue(className, type, name) {
-	var value = className;
-	switch(type) {
-		case 'method':
-			value += '::' + name + '()';
-			break;
-		case 'property':
-			value += '::$' + name;
-			break;
-		case 'class':
-			break;
+	// Handler on select
+	function selectResult(event, ui) {
+		var destination = ui.item.value;
+		var path = destination.replace(/\\/g, "/");
+		window.location.href = webroot + base + path;
 	}
-	return value;
-}
+
+	// jQuery UI Autocomplete source
+	function getResults(term, callback) {
+		var options = [];
+		$.get(
+			webroot + 'li3_docs/search/' + term.term,
+			function(data, status, xhr) {
+				if(typeof(data.results.error) != 'undefined') {
+					alert(data.results.error);
+					return;
+				}
+				for(var i in data.results) {
+					options.push(createValue(
+						data.results[i]['class'],
+						data.results[i].type,
+						data.results[i].name
+					));
+				}
+				callback(options);
+			},
+			'json'
+		);
+	}
+
+	// Transforms symbol results into displayable options
+	function createValue(className, type, name) {
+		var value = className;
+		switch(type) {
+			case 'method':
+				value += '::' + name + '()';
+				break;
+			case 'property':
+				value += '::$' + name;
+				break;
+			case 'class':
+				break;
+		}
+		return value;
+	}
+
+})();
+


### PR DESCRIPTION
The `'url'` option for li3_docs only affected a small amount of the routing. It now properly works for the breadcrumb urls and search. Also updated the image urls in the css to be relative so this can be placed in a different location.

Updated the README with a couple examples of how the url option can be used.
