### PR TITLE
Disable parsing of tests files.

### DIFF
--- a/extensions/docs/Extractor.php
+++ b/extensions/docs/Extractor.php
@@ -182,7 +182,7 @@ class Extractor extends \lithium\core\StaticObject {
 		$classes = Libraries::find($object['library'], array('recursive' => true));
 
 		$proto['subClasses'] = array_filter($classes, function($class) use ($identifier) {
-			if (preg_match('/\\\(libraries)\\\|\\\(mocks)\\\/', $class)) {
+			if (preg_match('/\\\(libraries)\\\|\\\(mocks)\\\|\\\(tests)\\\/', $class)) {
 				return false;
 			}
 			try {


### PR DESCRIPTION
This is related to the `Fatal error: Class 'li3_fixtures\test\Fixture' not found`issue.
