### PR TITLE
Updates domain to li3.me

### DIFF
--- a/config/install/li3_docs.json
+++ b/config/install/li3_docs.json
@@ -4,12 +4,12 @@
 	"summary": "the lithium docs plugin",
 	"description": "Automatically generates documentation from docblocks",
 	"maintainers":[
-		{"name": "gwoo", "website": "lithify.me"},
-		{"name": "nate", "website": "lithify.me"},
-		{"name": "nperson", "website": "lithify.me"}
+		{"name": "gwoo", "website": "li3.me"},
+		{"name": "nate", "website": "li3.me"},
+		{"name": "nperson", "website": "li3.me"}
 	],
 	"sources":[
-		"http:\/\/lab.lithify.me\/lab\/download\/li3_docs.phar.gz"
+		"http:\/\/lab.li3.me\/lab\/download\/li3_docs.phar.gz"
 	],
 	"commands":{
 		"install":[],"update":[],"remove":[]

--- a/views/layouts/default.html.php
+++ b/views/layouts/default.html.php
@@ -85,7 +85,7 @@ if ($searchBase !== "") {
 		$(document).ready(function () {
 			RadCli.setup({
 				setupGitCopy: false,
-				commandBase: 'http://lithify.me/<?= Locale::language(Environment::get('locale')); ?>/cmd'
+				commandBase: 'http://li3.me/<?= Locale::language(Environment::get('locale')); ?>/cmd'
 			});
 			$('#header').css({ borderTop: '40px solid black' });
 		});

--- a/webroot/js/rad.cli.js
+++ b/webroot/js/rad.cli.js
@@ -8,8 +8,8 @@
 var RadCli = {
 	options: {
 		div: null,
-		assetBase: 'http://lithify.me',
-		commandBase: 'http://lithify.me/cmd'
+		assetBase: 'http://li3.me',
+		commandBase: 'http://li3.me/cmd'
 	},
 	html: {
 		cli: null,


### PR DESCRIPTION
- Change domain referenced from lithify.me (currently unregistered as of 2014-01-04 and not resolving) to li3.me (currently resolving just fine)

It's possible I've got the wrong end of the stick, but the docs at http://li3.me/ still point to lithify.me
